### PR TITLE
mmc: fix boot from eMMC

### DIFF
--- a/drivers/mmc/mmc.c
+++ b/drivers/mmc/mmc.c
@@ -1723,7 +1723,7 @@ int mmc_start_init(struct mmc *mmc)
 		return 0;
 
 	if (mmc->init_in_progress)
-		goto out;
+		return 0;
 
 	err = mmc_get_op_cond(mmc); 
 
@@ -1734,7 +1734,6 @@ int mmc_start_init(struct mmc *mmc)
 	} else
 		mmc->init_in_progress = 1;
 
-out:
 	return err;
 }
 


### PR DESCRIPTION
When mmc_getcd() returns 1 and init_in_progress is true, the mmc_getcd()
return value is returned to the mmc_start_init() caller, that interprets
it as an error. Just return 0 in this case.

Signed-off-by: Baruch Siach <baruch@tkos.co.il>