### PR TITLE
tools/imx8m_image.sh: remove bashism

### DIFF
--- a/tools/imx8m_image.sh
+++ b/tools/imx8m_image.sh
@@ -12,7 +12,7 @@ blobs=`awk '/^SIGNED_HDMI/ {print $2} /^LOADER/ {print $2} /^SECOND_LOADER/ {pri
 for f in $blobs; do
 	tmp=$srctree/$f
 
-	if [ $f == "spl/u-boot-spl-ddr.bin" ] || [ $f == "u-boot.itb" ]; then
+	if [ $f = "spl/u-boot-spl-ddr.bin" ] || [ $f = "u-boot.itb" ]; then
 		continue
 	fi
 
@@ -28,7 +28,7 @@ for f in $blobs; do
 	sed -in "s;$f;$tmp;" $file
 done
 
-if [ $post_process == 1 ]; then
+if [ $post_process = 1 ]; then
 	if [ -f $srctree/lpddr4_pmu_train_1d_imem.bin ]; then
 		objcopy -I binary -O binary --pad-to 0x8000 --gap-fill=0x0 $srctree/lpddr4_pmu_train_1d_imem.bin lpddr4_pmu_train_1d_imem_pad.bin
 		objcopy -I binary -O binary --pad-to 0x4000 --gap-fill=0x0 $srctree/lpddr4_pmu_train_1d_dmem.bin lpddr4_pmu_train_1d_dmem_pad.bin


### PR DESCRIPTION
Use a single '=' to test string equality for compatibility with non-bash
shells. Otherwise, if /bin/sh is dash, build fails:

./tools/imx8m_image.sh: 15: [: signed_hdmi_imx8m.bin: unexpected operator
./tools/imx8m_image.sh: 15: [: signed_hdmi_imx8m.bin: unexpected operator
./tools/imx8m_image.sh: 15: [: spl/u-boot-spl-ddr.bin: unexpected operator
./tools/imx8m_image.sh: 15: [: spl/u-boot-spl-ddr.bin: unexpected operator
WARNING './spl/u-boot-spl-ddr.bin' not found, resulting binary is not-functional

Signed-off-by: Baruch Siach <baruch@tkos.co.il>