### PR TITLE
ddr: marvell: only assert M_ODT[0] on write for a single CS

### DIFF
--- a/drivers/ddr/marvell/a38x/ddr3_init.h
+++ b/drivers/ddr/marvell/a38x/ddr3_init.h
@@ -183,7 +183,8 @@ extern u32 g_znodt_data;
 extern u32 g_zpodt_ctrl;
 extern u32 g_znodt_ctrl;
 extern u32 g_dic;
-extern u32 g_odt_config;
+extern u32 g_odt_config_2cs;
+extern u32 g_odt_config_1cs;
 extern u32 g_rtt_nom;
 
 extern u8 debug_training_access;

--- a/drivers/ddr/marvell/a38x/ddr3_training.c
+++ b/drivers/ddr/marvell/a38x/ddr3_training.c
@@ -300,6 +300,7 @@ int hws_ddr3_tip_init_controller(u32 dev_num, struct init_cntr_param *init_cntr_
 	enum hws_access_type access_type = ACCESS_TYPE_UNICAST;
 	u32 data_read[MAX_INTERFACE_NUM];
 	struct hws_topology_map *tm = ddr3_get_topology_map();
+	u32 odt_config = g_odt_config_2cs;
 
 	DEBUG_TRAINING_IP(DEBUG_LEVEL_TRACE,
 			  ("Init_controller, do_mrs_phy=%d, is_ctrl64_bit=%d\n",
@@ -555,6 +556,9 @@ int hws_ddr3_tip_init_controller(u32 dev_num, struct init_cntr_param *init_cntr_
 				      DUNIT_CONTROL_HIGH_REG,
 				      (init_cntr_prm->msys_init << 7), (1 << 7)));
 
+			/* calculate number of CS (per interface) */
+			CHECK_STATUS(calc_cs_num
+				     (dev_num, if_id, &cs_num));
 			timing = tm->interface_params[if_id].timing;
 
 			if (mode2_t != 0xff) {
@@ -563,9 +567,6 @@ int hws_ddr3_tip_init_controller(u32 dev_num, struct init_cntr_param *init_cntr_
 				/* Board topology map is forcing timing */
 				t2t = (timing == HWS_TIM_2T) ? 1 : 0;
 			} else {
-				/* calculate number of CS (per interface) */
-				CHECK_STATUS(calc_cs_num
-					     (dev_num, if_id, &cs_num));
 				t2t = (cs_num == 1) ? 0 : 1;
 			}
 
@@ -608,9 +609,11 @@ int hws_ddr3_tip_init_controller(u32 dev_num, struct init_cntr_param *init_cntr_
 				      (1 << 11)));
 
 			/* Set Active control for ODT write transactions */
+			if (cs_num == 1)
+				odt_config = g_odt_config_1cs;
 			CHECK_STATUS(ddr3_tip_if_write
 				     (dev_num, ACCESS_TYPE_MULTICAST,
-				      PARAM_NOT_CARE, 0x1494, g_odt_config,
+				      PARAM_NOT_CARE, 0x1494, odt_config,
 				      MASK_ALL_BITS));
 		}
 	} else {
@@ -1524,7 +1527,7 @@ int ddr3_tip_freq_set(u32 dev_num, enum hws_access_type access_type,
 		CHECK_STATUS(ddr3_tip_if_write(dev_num, access_type,
 					       if_id, ODT_TIMING_LOW,
 					       val, 0xffff0));
-		val = 0x71 | ((cwl_value - 1) << 8) | ((cwl_value + 5) << 12);
+		val = 0x91 | ((cwl_value - 1) << 8) | ((cwl_value + 5) << 12);
 		CHECK_STATUS(ddr3_tip_if_write(dev_num, access_type,
 					       if_id, ODT_TIMING_HI_REG,
 					       val, 0xffff));
@@ -1576,7 +1579,7 @@ static int ddr3_tip_write_odt(u32 dev_num, enum hws_access_type access_type,
 
 	CHECK_STATUS(ddr3_tip_if_write(dev_num, access_type, if_id,
 				       ODT_TIMING_LOW, val, 0xffff0));
-	val = 0x71 | ((cwl_value - 1) << 8) | ((cwl_value + 5) << 12);
+	val = 0x91 | ((cwl_value - 1) << 8) | ((cwl_value + 5) << 12);
 	CHECK_STATUS(ddr3_tip_if_write(dev_num, access_type, if_id,
 				       ODT_TIMING_HI_REG, val, 0xffff));
 	if (odt_additional == 1) {

--- a/drivers/ddr/marvell/a38x/ddr3_training_static.c
+++ b/drivers/ddr/marvell/a38x/ddr3_training_static.c
@@ -21,7 +21,8 @@ u32 g_zpodt_data = 45;		/* controller data - P ODT */
 u32 g_znodt_data = 45;		/* controller data - N ODT */
 u32 g_zpodt_ctrl = 45;		/* controller data - P ODT */
 u32 g_znodt_ctrl = 45;		/* controller data - N ODT */
-u32 g_odt_config = 0x120012;
+u32 g_odt_config_2cs = 0x120012;
+u32 g_odt_config_1cs = 0x30000;
 u32 g_rtt_nom = 0x44;
 u32 g_dic = 0x2;
 


### PR DESCRIPTION
When using only a single DDR chip select only assert M_ODT[0] on write.
Do not assert it on read and do not assert M_ODT[1] at all. Also set
tODT_OFF_WR to 0x9 which contradicts the recommendation from the
functional spec but is what Marvell's binary training blob does and
seems to give better results when ODT is active during writes.

Signed-off-by: Chris Packham <judge.packham@gmail.com>
Signed-off-by: Stefan Roese <sr@denx.de>
(cherry picked from commit dbaf09590df9add19e738d2de03c0f2d0d8f5433)
[baruch: assert M_ODT[0] on write for CS1 as well; SolidRun A388 SOM
 with two DDR chips needs this since only M_ODT[0] is connected]
Signed-off-by: Baruch Siach <baruch@tkos.co.il>