### PR TITLE
board: solidrun: clearfog: enable ddr odt0 on write for both chip-select

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,6 +159,14 @@ jobs:
           make -j$(nproc)
           install -v -m644 -D u-boot-with-spl.kwb deploy/u-boot-clearfog-base-uart.kwb
 
+      - name: Upload to GitHub
+        uses: actions/upload-artifact@v4
+        if: github.event_name == 'pull_request'
+        with:
+          name: a38x-uboot-${{ steps.tag_step.outputs.build_ver }}_${{ steps.tag_step.outputs.build_tag }}
+          path: deploy/
+          if-no-files-found: error
+
       - name: Upload to S3
         if: github.ref == 'refs/heads/v2024.04-solidrun-a38x' && github.event_name != 'pull_request'
         uses: shallwefootball/upload-s3-action@v1.3.3

--- a/board/solidrun/clearfog/clearfog.c
+++ b/board/solidrun/clearfog/clearfog.c
@@ -161,7 +161,7 @@ static struct mv_ddr_topology_map board_topology_map = {
 	{0},				/* timing parameters */
 	{ {0} },			/* electrical configuration */
 	{0,},				/* electrical parameters */
-	0,				/* ODT configuration */
+	0x30000,			/* ODT configuration */
 	0x3,				/* clock enable mask */
 };
 


### PR DESCRIPTION
Enabling ODT is required to suppress reflection of the data signal on DDR write operation. SolidRun Armada 388 SoM only connects M_ODT[0] even when both chip-select are used.

Enable ODT[0] for both chip-select during write only.

Original work by Baruch Siach [1] and Chris Packham [2].

[1] https://github.com/SolidRun/u-boot-armada38x/commit/aba763a611e69fbcc4e229659da9d84f16b39814
[2] https://github.com/SolidRun/u-boot-armada38x/commit/dbaf09590df9add19e738d2de03c0f2d0d8f5433

Please do not submit a Pull Request via github.  Our project makes use of
mailing lists for patch submission and review.  For more details please
see https://www.denx.de/wiki/U-Boot/Patches
